### PR TITLE
kinect fov and face rot now cycles + normals out of facedata

### DIFF
--- a/Nodes/VVVV.DX11.Nodes.MSKinect/Nodes/KinectFaceDataNode.cs
+++ b/Nodes/VVVV.DX11.Nodes.MSKinect/Nodes/KinectFaceDataNode.cs
@@ -8,6 +8,7 @@ using SlimDX;
 using VVVV.DX11.Nodes.MSKinect;
 using VVVV.MSKinect.Lib;
 using VVVV.PluginInterfaces.V2;
+using VVVV.Utils.VMath;
 
 namespace MSKinect.Nodes
 {
@@ -19,7 +20,6 @@ namespace MSKinect.Nodes
 	            Help = "Returns detailed 2D and 3D data describing the tracked face")]
     public class KinectFaceFrameDataNode : IPluginEvaluate
     {
-
         [Input("Face", CheckIfChanged = true)]
         private Pin<FaceTrackFrame> FInFrame;
 
@@ -43,8 +43,6 @@ namespace MSKinect.Nodes
 
         [Output("Indices")]
         private ISpread<int> FOutIndices;
-
-        private float INVTWOPI = 0.5f / (float)Math.PI;
 
         private bool first = true;
 
@@ -72,7 +70,7 @@ namespace MSKinect.Nodes
                         FaceTrackFrame frame = this.FInFrame[cnt];
                         this.FOutOK[cnt] = frame.TrackSuccessful;
                         this.FOutPosition[cnt] = new Vector3(frame.Translation.X, frame.Translation.Y, frame.Translation.Z);
-                        this.FOutRotation[cnt] = new Vector3(frame.Rotation.X, frame.Rotation.Y, frame.Rotation.Z) * INVTWOPI;
+                        this.FOutRotation[cnt] = new Vector3(frame.Rotation.X, frame.Rotation.Y, frame.Rotation.Z) * (float)VMath.DegToCyc;
 
                         EnumIndexableCollection<FeaturePoint, PointF> pp = frame.GetProjected3DShape();
                         EnumIndexableCollection<FeaturePoint, Vector3DF> p = frame.Get3DShape();

--- a/Nodes/VVVV.DX11.Nodes.MSKinect/Nodes/KinectFaceNode.cs
+++ b/Nodes/VVVV.DX11.Nodes.MSKinect/Nodes/KinectFaceNode.cs
@@ -2,11 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Runtime.InteropServices;
+using System.ComponentModel.Composition;
+
 using VVVV.PluginInterfaces.V2;
 using VVVV.PluginInterfaces.V1;
-using System.Runtime.InteropServices;
+using VVVV.Utils.VMath;
 using VVVV.MSKinect.Lib;
-using System.ComponentModel.Composition;
+
 using SlimDX.Direct3D9;
 using SlimDX;
 using Microsoft.Kinect;
@@ -53,12 +56,8 @@ namespace VVVV.MSKinect.Nodes
         private Skeleton[] skeletonData;
         private readonly Dictionary<int, SkeletonFaceTracker> trackedSkeletons = new Dictionary<int, SkeletonFaceTracker>();
 
-        private float INVTWOPI = 0.5f / (float)Math.PI;
-
         private bool first = true;
         private DepthImageFormat olddepth;
-        
-
 
         [ImportingConstructor()]
         public KinectFaceNode(IPluginHost host)
@@ -106,7 +105,7 @@ namespace VVVV.MSKinect.Nodes
                         frames.Add((FaceTrackFrame)sft.frame.Clone());
                         this.FOutOK[cnt] = sft.frame.TrackSuccessful;
                         this.FOutPosition[cnt] = new Vector3(sft.frame.Translation.X, sft.frame.Translation.Y, sft.frame.Translation.Z);
-                        this.FOutRotation[cnt] = new Vector3(sft.frame.Rotation.X, sft.frame.Rotation.Y, sft.frame.Rotation.Z) * INVTWOPI;
+                        this.FOutRotation[cnt] = new Vector3(sft.frame.Rotation.X, sft.frame.Rotation.Y, sft.frame.Rotation.Z) * (float)VMath.DegToCyc;
 
                         EnumIndexableCollection<FeaturePoint, PointF> pp = sft.frame.GetProjected3DShape();
                         EnumIndexableCollection<FeaturePoint, Vector3DF> p = sft.frame.Get3DShape();

--- a/Nodes/VVVV.DX11.Nodes.MSKinect/Nodes/KinectRuntimeNode.cs
+++ b/Nodes/VVVV.DX11.Nodes.MSKinect/Nodes/KinectRuntimeNode.cs
@@ -191,10 +191,10 @@ namespace VVVV.MSKinect.Nodes
                 this.FOutAccelerometer[0] = acc;
 
                 this.FOutColorFOV[0] = new Vector2D(this.runtime.Runtime.ColorStream.NominalHorizontalFieldOfView,
-                    this.runtime.Runtime.ColorStream.NominalVerticalFieldOfView);
+                                                    this.runtime.Runtime.ColorStream.NominalVerticalFieldOfView) * (float)VMath.DegToCyc;
 
                 this.FOutDepthFOV[0] = new Vector2D(this.runtime.Runtime.DepthStream.NominalHorizontalFieldOfView,
-                    this.runtime.Runtime.DepthStream.NominalVerticalFieldOfView);
+                    								this.runtime.Runtime.DepthStream.NominalVerticalFieldOfView) * (float)VMath.DegToCyc;
             }
 
             this.FOutKCnt[0] = KinectSensor.KinectSensors.Count;


### PR DESCRIPTION
- all kinect fov and rotation (face) are now in cycles
- facedata now with normals output
- added DX11 tag to FaceData so node can be found better
