### PR TITLE
Fixes AsShared texture returning 0 on 64bits

### DIFF
--- a/Nodes/VVVV.DX11.Nodes/Nodes/Textures/2D/FromPointerTextureNode.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Textures/2D/FromPointerTextureNode.cs
@@ -18,7 +18,7 @@ namespace VVVV.DX11.Nodes.Textures
     public class PointerTextureNode : IPluginEvaluate, IDX11ResourceProvider
     {
         [Input("Pointer", IsSingle=true)]
-        protected IDiffSpread<uint> FPointer;
+        protected IDiffSpread<ulong> FPointer;
 
         [Output("Texture")]
         protected Pin<DX11Resource<DX11Texture2D>> FTextureOutput;
@@ -56,8 +56,7 @@ namespace VVVV.DX11.Nodes.Textures
 
                 try
                 {
-                	int p = unchecked((int) this.FPointer[0]);
-                    Texture2D tex = context.Device.OpenSharedResource<Texture2D>(new IntPtr(p));
+                    Texture2D tex = context.Device.OpenSharedResource<Texture2D>((IntPtr)this.FPointer[0]);
                     ShaderResourceView srv = new ShaderResourceView(context.Device, tex);
 
                     DX11Texture2D resource = DX11Texture2D.FromTextureAndSRV(context, tex, srv);

--- a/Nodes/VVVV.DX11.Nodes/Nodes/Textures/2D/ToSharedTextureNode.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Textures/2D/ToSharedTextureNode.cs
@@ -26,7 +26,7 @@ namespace VVVV.DX11.Nodes.Textures
         Pin<DX11Resource<DX11Texture2D>> FTextureIn;
 
         [Output("Pointer",IsSingle=true)]
-        ISpread<uint> FPointer;
+        ISpread<ulong> FPointer;
 
         private bool FRendered = false;
         private bool FUpdated = false;
@@ -76,7 +76,7 @@ namespace VVVV.DX11.Nodes.Textures
                             desc.MipLevels = 1;
                             this.tex = new Texture2D(context.Device, desc);
                             this.SharedResource = new SlimDX.DXGI.Resource(this.tex);
-                            this.FPointer[0] = (uint)SharedResource.SharedHandle.ToInt64();
+                            this.FPointer[0] = (ulong)SharedResource.SharedHandle;
                         }
 
                         this.AssignedContext.CurrentDeviceContext.CopyResource(this.FTextureIn[0][context].Resource, this.tex);


### PR DESCRIPTION
IntPtr is a platform dependent type so casting it to uint (32bits)
will loose precision on 64bit platforms making the pointer invalid
sometimes.

This fixes the problem by making the pins ulong (64bits) and not
casting to 32bits in any place, but all plugins or patches using
AsSharedTexture should be changed to 64bits / ulong too.
