### PR TITLE
DX11TempTargetRedererNode: pin to create rendertarget as shared

### DIFF
--- a/Nodes/VVVV.DX11.Nodes/Nodes/Renderers/Graphics/DX11TempTargetRendererNode.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Renderers/Graphics/DX11TempTargetRendererNode.cs
@@ -36,6 +36,9 @@ namespace VVVV.DX11
 
         [Input("Mip Map Levels", Order = 5)]
         protected IDiffSpread<int> FInMipLevel;
+
+        [Input("Shared Texture", Order = 6)]
+        protected IDiffSpread<bool> FInSharedTex;
         #endregion
 
         #region Output Pins
@@ -77,7 +80,8 @@ namespace VVVV.DX11
 
             if (this.FInAASamplesPerPixel.IsChanged
               || this.FInDoMipMaps.IsChanged
-              || this.FInMipLevel.IsChanged)
+              || this.FInMipLevel.IsChanged
+              || this.FInSharedTex.IsChanged)
             {
                 this.sd.Count = Convert.ToInt32(this.FInAASamplesPerPixel[0].Name);
                 this.sd.Quality = 0;
@@ -132,8 +136,8 @@ namespace VVVV.DX11
                         aacount = maxlevels;
                     }
 
-                    DX11RenderTarget2D temptarget = context.ResourcePool.LockRenderTarget(this.width, this.height, ti.format, new SampleDescription(aacount,aaquality), this.FInDoMipMaps[0], this.FInMipLevel[0]).Element;
-                    DX11RenderTarget2D temptargetresolve = context.ResourcePool.LockRenderTarget(this.width, this.height, ti.format, new SampleDescription(1, 0), this.FInDoMipMaps[0], this.FInMipLevel[0]).Element;
+                    DX11RenderTarget2D temptarget = context.ResourcePool.LockRenderTarget(this.width, this.height, ti.format, new SampleDescription(aacount, aaquality), this.FInDoMipMaps[0], this.FInMipLevel[0], this.FInSharedTex[0]).Element;
+                    DX11RenderTarget2D temptargetresolve = context.ResourcePool.LockRenderTarget(this.width, this.height, ti.format, new SampleDescription(1, 0), this.FInDoMipMaps[0], this.FInMipLevel[0], this.FInSharedTex[0]).Element;
 
                     targets[context] = temptarget;
                     targetresolve[context] = temptargetresolve;
@@ -144,11 +148,12 @@ namespace VVVV.DX11
                 else
                 {
                     //Bind both texture as same output
-                    DX11RenderTarget2D temptarget = context.ResourcePool.LockRenderTarget(this.width, this.height, ti.format, new SampleDescription(aacount, aaquality), this.FInDoMipMaps[0], this.FInMipLevel[0]).Element;
+                    DX11RenderTarget2D temptarget = context.ResourcePool.LockRenderTarget(this.width, this.height, ti.format, new SampleDescription(aacount, aaquality), this.FInDoMipMaps[0], this.FInMipLevel[0], this.FInSharedTex[0]).Element;
                     targets[context] = temptarget;
   
                     this.FOutBuffers[0][context] = temptarget;
                     this.FOutAABuffers[0][context] = temptarget;
+
                 }
 
 


### PR DESCRIPTION
Uses the changes in https://github.com/mrvux/FeralTic/pull/12 to allow the creation of a TempTargetRenderer with a shared render target. this allows to use the texture without having to use the ToShared plugin which avoids a texture copy
