### PR TITLE
fix for SetSlice and GetSlice Texture2DArray nodes

### DIFF
--- a/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/GetSliceTextureArray.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/GetSliceTextureArray.cs
@@ -83,7 +83,7 @@ namespace VVVV.DX11.Nodes
         
         public void Update(IPluginIO pin, DX11RenderContext context)
         {
-            if (this.FTextureOutput.SliceCount == 0 || !FTexIn.IsConnected) { return; }
+            if (this.FTextureOutput.SliceCount == 0 || !FTexIn.IsConnected || !FTexIn[0].Contains(context)) { return; }
 
             if (FTexIn.IsConnected)
             {

--- a/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/TextureArraySetSliceNode.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/TextureArraySetSliceNode.cs
@@ -47,7 +47,7 @@ namespace VVVV.DX11.Nodes
         protected ISpread<bool> FWrite;
 
         [Output("Texture Array", IsSingle = true)]
-        protected ISpread<DX11Resource<DX11Texture2D>> FOutTB;
+        protected ISpread<DX11Resource<DX11RenderTextureArray>> FOutTB;
 
         private TextureArraySetSlice generator;
 
@@ -55,7 +55,7 @@ namespace VVVV.DX11.Nodes
         {
             if (this.FOutTB[0] == null)
             {
-                this.FOutTB[0] = new DX11Resource<DX11Texture2D>();
+                this.FOutTB[0] = new DX11Resource<DX11RenderTextureArray>();
             }
         }
 


### PR DESCRIPTION
With this fix SetSlice will work with input Texture2DArray pin shader and GetSlice (DX11.TextureArray) node together.