### PR TITLE
Advanced version of buffer renderers and little usability tweak on Assimp SceneExplorer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "FeralTic"]
 	path = FeralTic
-	url = git@github.com:mrvux/FeralTic.git
+	url = https://github.com/mrvux/FeralTic.git
 [submodule "girlpower"]
 	path = girlpower
-	url = git@github.com:mrvux/dx11-vvvv-girlpower.git
+	url = https://github.com/mrvux/dx11-vvvv-girlpower.git

--- a/Nodes/VVVV.DX11.Nodes.Assimp/AssimpSceneExplorerNode.cs
+++ b/Nodes/VVVV.DX11.Nodes.Assimp/AssimpSceneExplorerNode.cs
@@ -39,6 +39,9 @@ namespace VVVV.DX11.Nodes.AssetImport
         [Input("Scene", IsSingle = true)]
         protected IDiffSpread<AssimpScene> FInScene;
 
+        [Output("Selected Node")]
+        protected ISpread<string> FOutSelectedNode;
+
         [Output("Mesh Id")]
         protected ISpread<int> FOutMeshId;
 
@@ -125,6 +128,7 @@ namespace VVVV.DX11.Nodes.AssetImport
 
                 this.FOutWorldTransform.SliceCount = transforms.Count;
                 this.FOutMeshId.SliceCount = meshes.Count;
+                FOutSelectedNode[0] = SelectedNode.Name;
                 for (int i = 0; i < meshes.Count;i++)
                 {
                     this.FOutWorldTransform[i] = transforms[i];

--- a/Nodes/VVVV.DX11.Nodes/Nodes/Layers/DX11ResetCounterNodeAdvanced.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Layers/DX11ResetCounterNodeAdvanced.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.ComponentModel.Composition;
+
+using VVVV.PluginInterfaces.V2;
+using VVVV.PluginInterfaces.V1;
+
+using FeralTic.DX11;
+using SlimDX.Direct3D11;
+using VVVV.DX11.Lib.Rendering;
+
+namespace VVVV.DX11.Nodes
+{
+    [PluginInfo(Name = "ResetCounter", Category = "DX11.Layer", Version = "Advanced", Author = "microdee")]
+    public class DX11AdvancedResetCounterNode : IPluginEvaluate, IDX11LayerProvider
+    {
+        [Input("Layer In")]
+        protected Pin<DX11Resource<DX11Layer>> FLayerIn;
+
+        [Input("RWStructuredBuffer Semantic")]
+        protected ISpread<string> FSemantic;
+
+        [Input("Reset Counter")]
+        protected ISpread<bool> FInReset;
+
+        [Input("Counter Value")]
+        protected ISpread<int> FInResetCounterValue;
+
+        [Output("Layer Out")]
+        protected ISpread<DX11Resource<DX11Layer>> FOutLayer;
+
+        public void Evaluate(int SpreadMax)
+        {
+            if (this.FOutLayer[0] == null) { this.FOutLayer[0] = new DX11Resource<DX11Layer>(); }
+        }
+
+        #region IDX11ResourceProvider Members
+        public void Update(IPluginIO pin, DX11RenderContext context)
+        {
+            if (!this.FOutLayer[0].Contains(context))
+            {
+                this.FOutLayer[0][context] = new DX11Layer();
+                this.FOutLayer[0][context].Render = this.Render;
+            }
+        }
+
+        public void Destroy(IPluginIO pin, DX11RenderContext context, bool force)
+        {
+            this.FOutLayer[0].Dispose(context);
+        }
+
+        public void Render(IPluginIO pin, DX11RenderContext context, DX11RenderSettings settings)
+        {
+            if (this.FLayerIn.IsConnected)
+            {
+                for (int i = 0; i < FSemantic.SliceCount; i++)
+                {
+                    RWStructuredBufferRenderSemantic ccrs = null;
+                    foreach (var rsem in settings.CustomSemantics)
+                    {
+                        if (rsem.Semantic == FSemantic[i])
+                        {
+                            if (rsem is RWStructuredBufferRenderSemantic)
+                            {
+                                ccrs = rsem as RWStructuredBufferRenderSemantic;
+                            }
+                        }
+                    }
+
+                    if (FInReset[i])
+                    {
+                        if (ccrs != null)
+                        {
+                            int[] resetval = { FInResetCounterValue[i] };
+                            var uavarray = new UnorderedAccessView[1] { ccrs.Data.UAV };
+                            context.CurrentDeviceContext.ComputeShader.SetUnorderedAccessViews(uavarray, 0, 1, resetval);
+                        }
+                    }
+                }
+                this.FLayerIn[0][context].Render(this.FLayerIn.PluginIO, context, settings);
+            }
+        }
+        #endregion
+    }
+}

--- a/Nodes/VVVV.DX11.Nodes/VVVV.DX11.Nodes.csproj
+++ b/Nodes/VVVV.DX11.Nodes/VVVV.DX11.Nodes.csproj
@@ -46,12 +46,14 @@
     <Compile Include="Nodes\Layers\DX11LayerBlendFactorNode.cs" />
     <Compile Include="Nodes\Layers\DX11LayerStencilRefNode.cs" />
     <Compile Include="Nodes\Layers\DX11LayerOrderNode.cs" />
+    <Compile Include="Nodes\Layers\DX11ResetCounterNodeAdvanced.cs" />
     <Compile Include="Nodes\Layers\DX11ResetCounterNode.cs" />
     <Compile Include="Nodes\Layers\Order\LayerZSortOrderNode.cs" />
     <Compile Include="Nodes\Layers\Order\LayerGetSliceOrderNode.cs" />
     <Compile Include="Nodes\Layers\Space\ViewPortBillboardNode.cs" />
     <Compile Include="Nodes\Renderers\Buffers\DX11BufferRendererAdvanced.cs" />
     <Compile Include="Nodes\Renderers\Buffers\DX11RawBufferRenderer.cs" />
+    <Compile Include="Nodes\Renderers\Buffers\DX11RawBufferRendererAdvanced.cs" />
     <Compile Include="Nodes\Renderers\Buffers\DX11StreamOutRendererNode.cs" />
     <Compile Include="Nodes\Renderers\Graphics\DX11Texture1dArrayRendererNode.cs" />
     <Compile Include="Nodes\Renderers\Graphics\DX11Texture1dRendererNode.cs" />


### PR DESCRIPTION
yo!

I've added my multi structured~ and rawbuffer renderer as Advanced versions of their originals (Renderer (DX11 Buffer Advanced) and Renderer (DX11 RawBuffer Advanced)). By this I've replaced the previous "advanced" buffer renderer as the only difference was that enum for the mode instead of a toggle which TBH didn't really justify a completely new node. Anyway this has a lot more control than the simple version.

So these work like this: if you spread the Semantic pin it will bind that many buffers to the incoming layers by the name you specify. You can also spread the options like size, strides, mode, reset counter/value etc. SRV's can be optionally binded about the same resources with again their unique semantics.

Complementary ResetCounter (DX11.Layer Advanced) is added too so you can reset counter in-between layers on individual counter/appendbuffer addressed by their binded semantics.

Also out of comfort I've added a string output to Assimp SceneExplorer which can help a lot copy/pasting skeleton joint names in vvvv.

Enjoy! and merge if you like it ;)