### PR TITLE
Validator ViewportIndex more useful

### DIFF
--- a/Core/VVVV.DX11.Lib/Rendering/Validators/DX11ViewportValidator.cs
+++ b/Core/VVVV.DX11.Lib/Rendering/Validators/DX11ViewportValidator.cs
@@ -13,6 +13,8 @@ namespace VVVV.DX11.Validators
 
         public bool Enabled { get; set; }
 
+        public int ViewPortCount { get; set; }
+
         public void SetGlobalSettings(DX11RenderSettings settings)
         {
             this.settings = settings;
@@ -21,7 +23,7 @@ namespace VVVV.DX11.Validators
 
         public bool Validate(DX11ObjectRenderSettings obj)
         {
-            return obj.DrawCallIndex == settings.ViewportIndex;
+            return obj.DrawCallIndex % ViewPortCount == settings.ViewportIndex;
         }
 
         public void Reset()

--- a/Nodes/VVVV.DX11.Nodes/Nodes/Validators/ViewportValidatorNode.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Validators/ViewportValidatorNode.cs
@@ -19,6 +19,9 @@ namespace VVVV.DX11.Nodes
         [Input("Enabled", DefaultValue = 1)]
         protected ISpread<bool> FInEnabled;
 
+        [Input("ViewportCount", DefaultValue = 1, IsSingle =true)]
+        protected ISpread<int> FViewportCount;
+
         [Output("Output", IsSingle = true)]
         protected ISpread<DX11ViewportValidator> FOut;
 
@@ -26,6 +29,7 @@ namespace VVVV.DX11.Nodes
         {
             if (this.FOut[0] == null) { this.FOut[0] = new DX11ViewportValidator(); }
             this.FOut[0].Enabled = this.FInEnabled[0];
+            this.FOut[0].ViewPortCount = this.FViewportCount[0];
             this.FOut[0].Reset();
 
         }


### PR DESCRIPTION
DX11ViewportValidator can handle cases with more objects than viewports (simple modulo over viewportcount)