### PR TITLE
little abstraction layer: IDX11ShaderVariableManager

### DIFF
--- a/Core/VVVV.DX11.Lib/Effects/DX11ShaderNode.cs
+++ b/Core/VVVV.DX11.Lib/Effects/DX11ShaderNode.cs
@@ -41,7 +41,7 @@ namespace VVVV.DX11.Nodes.Layers
     [PluginInfo(Name = "ShaderNode", Category = "DX11", Version = "", Author = "vux")]
     public unsafe class DX11ShaderNode : DX11BaseShaderNode, IPluginBase, IPluginEvaluate, IDisposable, IDX11LayerHost, IPartImportsSatisfiedNotification
     {
-        private DX11ShaderVariableManager varmanager;
+        private IDX11ShaderVariableManager varmanager;
         private DX11Resource<DX11ShaderData> deviceshaderdata = new DX11Resource<DX11ShaderData>();
         private DX11ContextElement<DX11ObjectRenderSettings> objectSettings = new DX11ContextElement<DX11ObjectRenderSettings>();
         private DX11ContextElement<List<DX11ObjectRenderSettings>> orderedObjectSettings = new DX11ContextElement<List<DX11ObjectRenderSettings>>();
@@ -160,11 +160,14 @@ namespace VVVV.DX11.Nodes.Layers
             this.FFactory = factory;
             this.TechniqueEnumId = Guid.NewGuid().ToString();
 
-            this.varmanager = new DX11ShaderVariableManager(host, factory);
+            this.varmanager = GetVarManager(host, factory);
 
             this.FHost.CreateTransformInput("Transform In", TSliceMode.Dynamic, TPinVisibility.True, out this.FInWorld);
         }
         #endregion
+
+        protected virtual IDX11ShaderVariableManager GetVarManager(IPluginHost host, IIOFactory iofactor)
+            => new DX11ShaderVariableManager(host, iofactor);        
 
         #region Evaluate
         public void Evaluate(int SpreadMax)

--- a/Core/VVVV.DX11.Lib/Effects/DX11ShaderVariableCache.cs
+++ b/Core/VVVV.DX11.Lib/Effects/DX11ShaderVariableCache.cs
@@ -19,7 +19,7 @@ namespace VVVV.DX11.Lib.Effects
         //private List<Action> 
 
         private DX11RenderSettings globalsettings;
-        public DX11ShaderVariableCache(DX11RenderContext context,DX11ShaderInstance shader, DX11ShaderVariableManager shaderManager)
+        public DX11ShaderVariableCache(DX11RenderContext context,DX11ShaderInstance shader, IDX11ShaderVariableManager shaderManager)
         {
             shaderPins = shaderManager.ShaderPins.VariablesList;
             for (int i = 0; i < shaderPins.Count;i++)

--- a/Core/VVVV.DX11.Lib/Effects/DX11ShaderVariableManager.cs
+++ b/Core/VVVV.DX11.Lib/Effects/DX11ShaderVariableManager.cs
@@ -15,19 +15,33 @@ using VVVV.DX11.Effects;
 
 namespace VVVV.DX11.Lib.Effects
 {
-    public class DX11ShaderVariableManager
+    public interface IDX11ShaderVariableManager
+    {
+        ShaderPinDictionary ShaderPins { get; }
+        WorldRenderVariableDictionary WorldVariables { get; }
+        RenderVariableDictionary RenderVariables { get; }
+        void SetShader(DX11Effect shader);
+        void CreateShaderPins();
+        List<string> GetCustomData();
+        void UpdateShaderPins();
+        void ApplyUpdates();
+        int CalculateSpreadMax();
+        bool SetGlobalSettings(DX11ShaderInstance shaderInstance, DX11RenderSettings settings);
+    }
+
+    public class DX11ShaderVariableManager : IDX11ShaderVariableManager
     {
         protected DX11Effect shader;
-        private IPluginHost host;
-        private IIOFactory iofactory;
+        protected IPluginHost host;
+        protected IIOFactory iofactory;
 
-        private ShaderPinDictionary shaderpins = new ShaderPinDictionary();
-        private RenderVariableDictionary rendervariables = new RenderVariableDictionary();
-        private WorldRenderVariableDictionary worldvariables = new WorldRenderVariableDictionary();
+        protected ShaderPinDictionary shaderpins = new ShaderPinDictionary();
+        protected RenderVariableDictionary rendervariables = new RenderVariableDictionary();
+        protected WorldRenderVariableDictionary worldvariables = new WorldRenderVariableDictionary();
 
-        private List<IDX11CustomRenderVariable> customvariables = new List<IDX11CustomRenderVariable>();
+        protected List<IDX11CustomRenderVariable> customvariables = new List<IDX11CustomRenderVariable>();
 
-        private DX11RenderSettings globalsettings;
+        protected DX11RenderSettings globalsettings;
 
         public DX11ShaderVariableManager(IPluginHost host, IIOFactory iofactory)
         {
@@ -94,7 +108,7 @@ namespace VVVV.DX11.Lib.Effects
         #endregion
 
         #region Create Pin
-        private void CreatePin(EffectVariable var)
+        protected virtual void CreatePin(EffectVariable var)
         {
             
             if (var.AsInterface() != null)
@@ -182,6 +196,5 @@ namespace VVVV.DX11.Lib.Effects
             }
             return csd;
         }
-
     }
 }

--- a/Core/VVVV.DX11.Lib/Effects/Pins/IShaderPin.cs
+++ b/Core/VVVV.DX11.Lib/Effects/Pins/IShaderPin.cs
@@ -13,7 +13,6 @@ namespace VVVV.DX11.Internals.Effects.Pins
     public interface IShaderPin : IShaderVariable
     {
         void Initialize(IIOFactory factory, EffectVariable variable);
-        string PinName { get; }
         bool Constant { get; }
         int SliceCount { get; }
         Action<int> CreateAction(DX11ShaderInstance instance);


### PR DESCRIPTION
hi vux! 

i have some few changes that would allow the community to play with shader graphs without the need of forking your repo. The main idea of the changes is just to abstract over the way how variables get routed to the shader.

abstracted over DX11ShaderVariableManager via IDX11ShaderVariableManager
* DX11ShaderNode now can be used as a base class for a shader graph sink.
* adjusted DX11ShaderVariableManager so that it also can serve as a base implementation of IDX11ShaderVariableManager.
* removed PinName from IShaderPin as it felt unused (at least in this solution) please recheck