### PR TITLE
[text3d] fixed huge memory leak when recreating text geometry

### DIFF
--- a/Nodes/VVVV.DX11.Nodes.Text3d/Extruder.cs
+++ b/Nodes/VVVV.DX11.Nodes.Text3d/Extruder.cs
@@ -34,6 +34,7 @@ namespace VVVV.DX11.Text3d
             geometry.Simplify(GeometrySimplificationOption.Lines, tolerance, sink);
 
             sink.Close();
+            sink.Dispose();
 
             return path;
         }
@@ -47,6 +48,7 @@ namespace VVVV.DX11.Text3d
             geometry.Outline(sink);
 
             sink.Close();
+            sink.Dispose();
 
             return path;
         }
@@ -80,10 +82,9 @@ namespace VVVV.DX11.Text3d
 
             outlinedGeometry.Tessellate(sink);
 
-            flattenedGeometry.Dispose();
             outlinedGeometry.Dispose();
-
-
+            flattenedGeometry.Dispose();
+            sink.Dispose();
 
             return vertices;
         }

--- a/Nodes/VVVV.DX11.Nodes.Text3d/ExtrudingSink.cs
+++ b/Nodes/VVVV.DX11.Nodes.Text3d/ExtrudingSink.cs
@@ -169,7 +169,7 @@ namespace VVVV.DX11.Text3d
 
         public void Dispose()
         {
-
+            Shadow.Dispose();
         }
 
         public void AddTriangles(Triangle[] triangles)

--- a/Nodes/VVVV.DX11.Nodes.Text3d/OutlineRenderer.cs
+++ b/Nodes/VVVV.DX11.Nodes.Text3d/OutlineRenderer.cs
@@ -54,6 +54,7 @@ namespace VVVV.DX11.Text3d
                 TransformedGeometry tg = new TransformedGeometry(this.factory, pg, *(RawMat*)&mat);
 
                 pg.Dispose();
+                sink.Dispose();
 
                 //Transform from baseline
 
@@ -87,6 +88,7 @@ namespace VVVV.DX11.Text3d
             Matrix3x2 mat = Matrix3x2.Translation(baselineOriginX, baselineOriginY) * Matrix3x2.Scaling(1.0f, -1.0f);
             TransformedGeometry tg = new TransformedGeometry(this.factory, pg, *(RawMat*)&mat);
             pg.Dispose();
+            sink.Dispose();
 
             this.AddGeometry(tg);
             return Result.Ok;
@@ -111,6 +113,7 @@ namespace VVVV.DX11.Text3d
             Matrix3x2 mat = Matrix3x2.Translation(baselineOriginX, baselineOriginY) * Matrix3x2.Scaling(1.0f, -1.0f);
             TransformedGeometry tg = new TransformedGeometry(this.factory, pg, *(RawMat*)&mat);
             pg.Dispose();
+            sink.Dispose();
 
             this.AddGeometry(tg);
             return Result.Ok;
@@ -160,6 +163,7 @@ namespace VVVV.DX11.Text3d
                 this.geometry.Combine(geom, CombineMode.Union, sink);
 
                 sink.Close();
+                sink.Dispose();
 
                 this.geometry = pg;
             }

--- a/Nodes/VVVV.DX11.Nodes.Text3d/Text3dNode.cs
+++ b/Nodes/VVVV.DX11.Nodes.Text3d/Text3dNode.cs
@@ -67,7 +67,13 @@ namespace VVVV.DX11.Nodes
 
             tl.Draw(renderer, 0.0f, 0.0f);
 
-            var result = ex.GetVertices(renderer.GetGeometry(), this.FExtrude[slice]);
+            var geometry = renderer.GetGeometry();
+            var result = ex.GetVertices(geometry, this.FExtrude[slice]);
+
+            renderer.Dispose();
+            geometry.Dispose();
+            tl.Dispose();
+            fmt.Dispose();
 
             Vector3 min = new Vector3(float.MaxValue);
             Vector3 max = new Vector3(float.MinValue);


### PR DESCRIPTION
disposing everything there is to dispose, especially the shadow object. fixes the leak.

Test patch:
[Text (DX11.Geometry) MemLeak.v4p.zip](https://github.com/mrvux/dx11-vvvv/files/1080852/Text.DX11.Geometry.MemLeak.v4p.zip)
