### PR TITLE
2 new Nodes that deal with TextureArrays

### DIFF
--- a/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/CopySubArray.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/CopySubArray.cs
@@ -29,12 +29,14 @@ namespace VVVV.DX11.Nodes
             this.context = context;
         }
 
+
         public void Reset(DX11Texture2D texture, int w, int h, int d, SlimDX.DXGI.Format format)
         {
             format = format == SlimDX.DXGI.Format.Unknown ? texture.Format : format;
             this.rtarr.Dispose();
             this.rtarr = new DX11RenderTextureArray(this.context, w, h, d, format, true, 1);
         }
+
 
         public void Apply(DX11Resource<DX11RenderTextureArray> textureArray, ISpread<int> slices)
         {
@@ -71,11 +73,9 @@ namespace VVVV.DX11.Nodes
 
                 int sourceSubres = SlimDX.Direct3D11.Texture2D.CalculateSubresourceIndex(0, slice, descIn.MipLevels);
 
-                int destinationSubres = SlimDX.Direct3D11.Texture2D.CalculateSubresourceIndex(0, 0, 1);
-
+                int destinationSubres = SlimDX.Direct3D11.Texture2D.CalculateSubresourceIndex(0, i, descIn.MipLevels);
 
                 context.CurrentDeviceContext.CopySubresourceRegion(source, sourceSubres, this.rtarr.Resource, destinationSubres, 0, 0, 0);
-
             }
             
         }

--- a/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/CopySubArray.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/CopySubArray.cs
@@ -29,15 +29,6 @@ namespace VVVV.DX11.Nodes
             this.context = context;
         }
 
-
-        public void Reset(DX11Texture2D texture, int w, int h, int d, SlimDX.DXGI.Format format)
-        {
-            format = format == SlimDX.DXGI.Format.Unknown ? texture.Format : format;
-            this.rtarr.Dispose();
-            this.rtarr = new DX11RenderTextureArray(this.context, w, h, d, format, true, 1);
-        }
-
-
         public void Apply(DX11Resource<DX11RenderTextureArray> textureArray, ISpread<int> slices)
         {
             int w = textureArray[context].Width;
@@ -50,10 +41,10 @@ namespace VVVV.DX11.Nodes
             // check if parameters match - if not, create a new rt array
             if (this.rtarr != null)
             {
-                if (this.rtarr.ElemCnt != slices.SliceCount || 
-                    this.rtarr.Width != w || 
-                    this.rtarr.Height != h || 
-                    this.rtarr.Format != f)
+                if (this.rtarr.ElemCnt != d || 
+                    this.rtarr.Width   != w || 
+                    this.rtarr.Height  != h || 
+                    this.rtarr.Format  != f)
                 {
                     this.rtarr.Dispose(); this.rtarr = null;
                 }

--- a/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/CopySubArray.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/CopySubArray.cs
@@ -44,6 +44,7 @@ namespace VVVV.DX11.Nodes
                 if (this.rtarr.ElemCnt != d || 
                     this.rtarr.Width   != w || 
                     this.rtarr.Height  != h || 
+                    this.rtarr.Description.MipLevels != descIn.MipLevels ||
                     this.rtarr.Format  != f)
                 {
                     this.rtarr.Dispose(); this.rtarr = null;
@@ -52,7 +53,7 @@ namespace VVVV.DX11.Nodes
 
             if (this.rtarr == null)
             {
-                this.rtarr = new DX11RenderTextureArray(this.context, w, h, d, f, true, 1);
+                this.rtarr = new DX11RenderTextureArray(this.context, w, h, d, f, true, descIn.MipLevels);
             }
 
             // copy the ressources over

--- a/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/CopySubArray.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/CopySubArray.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Reflection;
+using FeralTic.Resources.Geometry;
+using SlimDX.Direct3D11;
+using SlimDX.DXGI;
+
+using VVVV.PluginInterfaces.V1;
+using VVVV.PluginInterfaces.V2;
+
+using FeralTic.DX11;
+using FeralTic.DX11.Resources;
+using VVVV.Utils.VMath;
+
+namespace VVVV.DX11.Nodes
+{
+    public class CopySubArray : IDX11Resource, IDisposable
+    {
+        private DX11RenderContext context;
+
+        private DX11RenderTextureArray rtarr;
+        public DX11RenderTextureArray Result { get { return rtarr; } }
+
+
+        public CopySubArray(DX11RenderContext context)
+        {
+            this.context = context;
+        }
+
+        public void Reset(DX11Texture2D texture, int w, int h, int d, SlimDX.DXGI.Format format)
+        {
+            format = format == SlimDX.DXGI.Format.Unknown ? texture.Format : format;
+            this.rtarr.Dispose();
+            this.rtarr = new DX11RenderTextureArray(this.context, w, h, d, format, true, 1);
+        }
+
+        public void Apply(DX11Resource<DX11RenderTextureArray> textureArray, ISpread<int> slices)
+        {
+            int w = textureArray[context].Width;
+            int h = textureArray[context].Height;
+            int d = slices.SliceCount;
+            Format f = textureArray[context].Format;
+
+            Texture2DDescription descIn = textureArray[context].Resource.Description;
+
+            // check if parameters match - if not, create a new rt array
+            if (this.rtarr != null)
+            {
+                if (this.rtarr.ElemCnt != slices.SliceCount || 
+                    this.rtarr.Width != w || 
+                    this.rtarr.Height != h || 
+                    this.rtarr.Format != f)
+                {
+                    this.rtarr.Dispose(); this.rtarr = null;
+                }
+            }
+
+            if (this.rtarr == null)
+            {
+                this.rtarr = new DX11RenderTextureArray(this.context, w, h, d, f, true, 1);
+            }
+
+            // copy the ressources over
+            for (int i = 0; i < slices.SliceCount; i++)
+            {
+                int slice = VMath.Zmod(slices[i], textureArray[context].ElemCnt);
+
+                SlimDX.Direct3D11.Resource source = textureArray[context].Resource;
+
+                int sourceSubres = SlimDX.Direct3D11.Texture2D.CalculateSubresourceIndex(0, slice, descIn.MipLevels);
+
+                int destinationSubres = SlimDX.Direct3D11.Texture2D.CalculateSubresourceIndex(0, 0, 1);
+
+
+                context.CurrentDeviceContext.CopySubresourceRegion(source, sourceSubres, this.rtarr.Resource, destinationSubres, 0, 0, 0);
+
+            }
+            
+        }
+
+       
+        public void Dispose()
+        {
+            if (this.rtarr != null) { this.rtarr.Dispose(); }
+        }
+    }
+}

--- a/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/CopySubArrayNode.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/CopySubArrayNode.cs
@@ -46,6 +46,7 @@ namespace VVVV.DX11.Nodes
             }
         }
 
+
         public void Update(DX11RenderContext context)
         {
             if (!this.generators.Contains(context))
@@ -59,15 +60,16 @@ namespace VVVV.DX11.Nodes
 
                 generator.Apply(this.FTexIn[0], this.FIndex);
                 this.WriteResult(generator, context);
-
             }
         }
+
 
         private void WriteResult(CopySubArray generator, DX11RenderContext context)
         {
             DX11RenderTextureArray result = generator.Result;
             this.FTextureOutput[0][context] = generator.Result;
         }
+
 
         public void Destroy(DX11RenderContext context, bool force)
         {
@@ -77,6 +79,7 @@ namespace VVVV.DX11.Nodes
             }
         }
 
+
         public void Dispose()
         {
             if (this.generators != null)
@@ -84,7 +87,7 @@ namespace VVVV.DX11.Nodes
                 this.generators.Dispose();
                 this.generators = null;
             }
-
         }
+
     }
 }

--- a/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/CopySubArrayNode.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/CopySubArrayNode.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.ComponentModel.Composition;
+
+
+using SlimDX;
+using SlimDX.Direct3D11;
+//using SlimDX.DXGI;
+
+using VVVV.PluginInterfaces.V1;
+using VVVV.PluginInterfaces.V2;
+
+using FeralTic.DX11.Geometry;
+using FeralTic.DX11.Resources;
+using FeralTic.DX11;
+using VVVV.DX11.Nodes;
+using VVVV.DX11;
+using VVVV.DX11.Lib.Rendering;
+
+using VVVV.Core.Logging;
+using VVVV.Utils.VMath;
+
+namespace VVVV.DX11.Nodes
+{
+    [PluginInfo(Name = "GetArray", Category = "DX11.TextureArray", Version = "", Author = "sebl")]
+    public class CopySubArrayNode : IPluginEvaluate, IDX11ResourceHost, IDisposable
+    {
+        [Input("TextureArray In", IsSingle = true)]
+        protected Pin<DX11Resource<DX11RenderTextureArray>> FTexIn;
+
+        [Input("Index")]
+        protected IDiffSpread<int> FIndex;
+
+        [Output("Textures Out")]
+        protected ISpread<DX11Resource<DX11RenderTextureArray>> FTextureOutput;
+
+        private DX11Resource<CopySubArray> generators = new DX11Resource<CopySubArray>();
+
+
+        public void Evaluate(int SpreadMax)
+        {
+            if (this.FTextureOutput[0] == null)
+            {
+                this.FTextureOutput[0] = new DX11Resource<DX11RenderTextureArray>();
+            }
+        }
+
+        public void Update(DX11RenderContext context)
+        {
+            if (!this.generators.Contains(context))
+            {
+                this.generators[context] = new CopySubArray(context);
+            }
+
+            if (this.FTexIn.IsConnected)
+            {
+                var generator = this.generators[context];
+
+                generator.Apply(this.FTexIn[0], this.FIndex);
+                this.WriteResult(generator, context);
+
+            }
+        }
+
+        private void WriteResult(CopySubArray generator, DX11RenderContext context)
+        {
+            DX11RenderTextureArray result = generator.Result;
+            this.FTextureOutput[0][context] = generator.Result;
+        }
+
+        public void Destroy(DX11RenderContext context, bool force)
+        {
+            if (this.generators != null && this.generators.Contains(context))
+            {
+                this.generators.Dispose(context);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (this.generators != null)
+            {
+                this.generators.Dispose();
+                this.generators = null;
+            }
+
+        }
+    }
+}

--- a/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/GetArrayNode.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/GetArrayNode.cs
@@ -24,7 +24,7 @@ using VVVV.Utils.VMath;
 namespace VVVV.DX11.Nodes
 {
     [PluginInfo(Name = "GetArray", Category = "DX11.TextureArray", Version = "", Author = "sebl")]
-    public class CopySubArrayNode : IPluginEvaluate, IDX11ResourceHost, IDisposable
+    public class GetArrayNode : IPluginEvaluate, IDX11ResourceHost, IDisposable
     {
         [Input("TextureArray In", IsSingle = true)]
         protected Pin<DX11Resource<DX11RenderTextureArray>> FTexIn;
@@ -32,10 +32,10 @@ namespace VVVV.DX11.Nodes
         [Input("Index")]
         protected IDiffSpread<int> FIndex;
 
-        [Output("Textures Out")]
+        [Output("TextureArray Out")]
         protected ISpread<DX11Resource<DX11RenderTextureArray>> FTextureOutput;
 
-        private DX11Resource<CopySubArray> generators = new DX11Resource<CopySubArray>();
+        private DX11Resource<CopySubArray> generator = new DX11Resource<CopySubArray>();
 
 
         public void Evaluate(int SpreadMax)
@@ -49,14 +49,14 @@ namespace VVVV.DX11.Nodes
 
         public void Update(DX11RenderContext context)
         {
-            if (!this.generators.Contains(context))
+            if (!this.generator.Contains(context))
             {
-                this.generators[context] = new CopySubArray(context);
+                this.generator[context] = new CopySubArray(context);
             }
 
             if (this.FTexIn.IsConnected)
             {
-                var generator = this.generators[context];
+                var generator = this.generator[context];
 
                 generator.Apply(this.FTexIn[0], this.FIndex);
                 this.WriteResult(generator, context);
@@ -73,19 +73,19 @@ namespace VVVV.DX11.Nodes
 
         public void Destroy(DX11RenderContext context, bool force)
         {
-            if (this.generators != null && this.generators.Contains(context))
+            if (this.generator != null && this.generator.Contains(context))
             {
-                this.generators.Dispose(context);
+                this.generator.Dispose(context);
             }
         }
 
 
         public void Dispose()
         {
-            if (this.generators != null)
+            if (this.generator != null)
             {
-                this.generators.Dispose();
-                this.generators = null;
+                this.generator.Dispose();
+                this.generator = null;
             }
         }
 

--- a/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/GetArraysNode.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/GetArraysNode.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.ComponentModel.Composition;
+
+
+using SlimDX;
+using SlimDX.Direct3D11;
+//using SlimDX.DXGI;
+
+using VVVV.PluginInterfaces.V1;
+using VVVV.PluginInterfaces.V2;
+
+using FeralTic.DX11.Geometry;
+using FeralTic.DX11.Resources;
+using FeralTic.DX11;
+using VVVV.DX11.Nodes;
+using VVVV.DX11;
+using VVVV.DX11.Lib.Rendering;
+
+using VVVV.Core.Logging;
+using VVVV.Utils.VMath;
+
+namespace VVVV.DX11.Nodes
+{
+    [PluginInfo(Name = "GetArray", Category = "DX11.TextureArray", Version = "BinSize", Author = "sebl")]
+    public class GetArraysNode : IPluginEvaluate, IDX11ResourceHost, IDisposable
+    {
+        [Input("TextureArray In", IsSingle = true)]
+        protected Pin<DX11Resource<DX11RenderTextureArray>> FTexIn;
+
+        [Input("Index")]
+        protected ISpread<ISpread<int>> FIndex;
+
+        [Output("TextureArray Out")]
+        protected ISpread<DX11Resource<DX11RenderTextureArray>> FTextureOutput;
+
+        private Spread<DX11Resource<CopySubArray>> generators = new Spread<DX11Resource<CopySubArray>>();
+        private int binSize;
+
+
+        public void Evaluate(int SpreadMax)
+        {
+            if (this.FTexIn.IsConnected)
+            {
+                binSize = FIndex.SliceCount;
+
+                // manage generators
+                if (generators.SliceCount > binSize)
+                {
+                    for (int i = generators.SliceCount; i > binSize; i--)
+                    {
+                        generators[i].Dispose();
+                    }
+                }
+
+                if (generators.SliceCount < binSize)
+                {
+                    for (int i = generators.SliceCount; i < binSize; i++)
+                    {
+                        generators.Add(new DX11Resource<CopySubArray>());
+                    }
+                }
+
+
+                // manage TextureOutput(s)
+                if (this.FTextureOutput.SliceCount > binSize)
+                {
+                    for (int t = binSize; t < this.FTextureOutput.SliceCount; t++)
+                    {
+                        if (this.FTextureOutput[t] != null)
+                            this.FTextureOutput[t].Dispose();
+
+                    }
+                }
+
+                FTextureOutput.SliceCount = binSize;
+
+                for (int i = 0; i < binSize; i++)
+                {
+                    if (this.FTextureOutput[i] == null)
+                    {
+                        this.FTextureOutput[i] = new DX11Resource<DX11RenderTextureArray>();
+                    }
+                }
+
+            }
+            else
+            {
+                for (int i = 0; i < FTextureOutput.SliceCount; i++)
+                {
+                    if (this.FTextureOutput[i] != null)
+                        this.FTextureOutput[i].Dispose();
+                }
+                FTextureOutput.SliceCount = 0;
+            }
+        }
+
+
+        public void Update(DX11RenderContext context)
+        {
+            if (this.FTexIn.IsConnected)
+            {
+                for (int i = 0; i < binSize; i++)
+                {
+                    if (!this.generators[i].Contains(context))
+                    {
+                        this.generators[i][context] = new CopySubArray(context);
+                    }
+
+                    var generator = this.generators[i][context];
+
+                    generator.Apply(this.FTexIn[0], this.FIndex[i]);
+                    this.WriteResult(generator, context, i);
+                }
+            }
+        }
+
+
+        private void WriteResult(CopySubArray generator, DX11RenderContext context, int slice)
+        {
+            DX11RenderTextureArray result = generator.Result;
+            this.FTextureOutput[slice][context] = generator.Result;
+        }
+
+
+        public void Destroy(DX11RenderContext context, bool force)
+        {
+            foreach (var g in generators)
+            {
+                if (g != null && g.Contains(context))
+                {
+                    g.Dispose(context);
+                }
+            }
+        }
+
+
+        public void Dispose()
+        {
+            foreach (var g in this.generators)
+            {
+                if (g != null)
+                {
+                    g.Dispose();
+                }
+            }
+            this.generators = null;
+        }
+
+    }
+}

--- a/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/GetSliceToArray.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/GetSliceToArray.cs
@@ -1,0 +1,148 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.ComponentModel.Composition;
+
+
+using SlimDX;
+using SlimDX.Direct3D11;
+//using SlimDX.DXGI;
+
+using VVVV.PluginInterfaces.V1;
+using VVVV.PluginInterfaces.V2;
+
+using FeralTic.DX11.Geometry;
+using FeralTic.DX11.Resources;
+using FeralTic.DX11;
+using VVVV.DX11.Nodes;
+using VVVV.DX11;
+using VVVV.DX11.Lib.Rendering;
+
+using VVVV.Core.Logging;
+using VVVV.Utils.VMath;
+
+namespace VVVV.DX11.Nodes
+{
+    [PluginInfo(Name = "GetSlice", Category = "DX11.TextureArray", Version = "To Array", Author = "sebl")]
+    public class GetSliceToArray : IPluginEvaluate, IDX11ResourceHost, IDisposable
+    {
+        [Input("Texture In")]
+        protected Pin<DX11Resource<DX11Texture2D>> FTexIn;
+
+        [Input("Index")]
+        protected ISpread<ISpread<int>> FIndex;
+
+        [Output("Textures Out")]
+        protected ISpread<DX11Resource<DX11RenderTextureArray>> FTextureOutput;
+
+        int numSlicesOut;
+
+        [Import()]
+        public ILogger logger;
+
+        public void Evaluate(int SpreadMax)
+        {
+            if (this.FTexIn.IsConnected)
+            {
+                this.numSlicesOut = this.FIndex.SliceCount;
+                this.FTextureOutput.SliceCount = this.numSlicesOut;
+
+                for (int i = 0; i < numSlicesOut; i++)
+                {
+                    if (this.FTextureOutput[i] == null)
+                    {
+                        this.FTextureOutput[i] = new DX11Resource<DX11RenderTextureArray>();
+                    }
+                }
+            }
+            else
+            {
+                for (int i = 0; i < FTextureOutput.SliceCount; i++)
+                {
+                    if (this.FTextureOutput[i] != null)
+                        this.FTextureOutput[i].Dispose();
+                }
+            }
+
+            this.FTextureOutput.SliceCount = this.numSlicesOut; // hmmmm...
+
+            if (this.FTextureOutput.SliceCount > this.numSlicesOut)
+            {
+                for (int t = numSlicesOut; t < this.FTextureOutput.SliceCount; t++)
+                {
+                    this.FTextureOutput[t].Dispose();
+                }
+            }
+        }
+
+        
+        public void Update(DX11RenderContext context)
+        {
+            if (this.FTextureOutput.SliceCount == 0 || !FTexIn.IsConnected || !FTexIn[0].Contains(context)) { return; }
+
+            if (FTexIn.IsConnected)
+            {
+                // first texture determines description; all input textures have to match w,h,d,f, mips, etc.
+                Texture2DDescription descIn = FTexIn[0][context].Resource.Description; 
+                Texture2DDescription descOut;
+
+                for (int i = 0; i < numSlicesOut; i++) // for each bin
+                {
+                    int currentArraySize = FIndex[i].SliceCount;
+
+                    for (int j = 0; j < currentArraySize; j++) // for each slice in that bin
+                    {
+                        int currentslice = FIndex[i][j];
+
+                        if (this.FTextureOutput[i].Contains(context))
+                        {
+                            descOut = this.FTextureOutput[i][context].Resource.Description;
+
+                            if (/*FIndex.IsChanged ||*/ 
+                                descIn.Format != descOut.Format || 
+                                descIn.Width != descOut.Width || 
+                                descIn.Height != descOut.Height)
+                            {
+                                // ToDo: check for mismatching descriptions and react accordingly...
+                                this.FTextureOutput[i][context] = new DX11RenderTextureArray(context, descIn.Width, descIn.Height, currentArraySize, descIn.Format, true, descIn.MipLevels);
+                            }
+                        }
+                        else
+                        {
+                            this.FTextureOutput[i][context] = new DX11RenderTextureArray(context, descIn.Width, descIn.Height, currentArraySize, descIn.Format, true, descIn.MipLevels);
+                        }
+
+                        if (this.FTextureOutput[i][context].Resource == null)
+                        {
+                            this.FTextureOutput[i][context] = new DX11RenderTextureArray(context, descIn.Width, descIn.Height, currentArraySize, descIn.Format, true, descIn.MipLevels);
+                        }
+
+                        SlimDX.Direct3D11.Resource source = this.FTexIn[currentslice][context].Resource;
+                        SlimDX.Direct3D11.Resource destination = this.FTextureOutput[i][context].Resource;
+
+                        int sourceSubres = SlimDX.Direct3D11.Texture2D.CalculateSubresourceIndex(0, 0, descIn.MipLevels);
+                        int destinationSubres = SlimDX.Direct3D11.Texture2D.CalculateSubresourceIndex(0, j, descIn.MipLevels);
+
+                        context.CurrentDeviceContext.CopySubresourceRegion(source, sourceSubres, destination, destinationSubres, 0, 0, 0);
+
+                    }
+                }
+            }
+        }
+
+
+        public void Dispose()
+        {
+            this.FTextureOutput.SafeDisposeAll();
+        }
+
+
+        public void Destroy(DX11RenderContext context, bool force)
+        {
+            this.FTextureOutput.SafeDisposeAll(context);
+        }
+
+
+    }
+}

--- a/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/GetSliceToArray.cs
+++ b/Nodes/VVVV.DX11.Nodes/Nodes/Textures/Array/GetSliceToArray.cs
@@ -102,7 +102,8 @@ namespace VVVV.DX11.Nodes
                             if (/*FIndex.IsChanged ||*/ 
                                 descIn.Format != descOut.Format || 
                                 descIn.Width != descOut.Width || 
-                                descIn.Height != descOut.Height)
+                                descIn.Height != descOut.Height ||
+                                descIn.MipLevels != descOut.MipLevels)
                             {
                                 // ToDo: check for mismatching descriptions and react accordingly...
                                 this.FTextureOutput[i][context] = new DX11RenderTextureArray(context, descIn.Width, descIn.Height, currentArraySize, descIn.Format, true, descIn.MipLevels);

--- a/Nodes/VVVV.DX11.Nodes/VVVV.DX11.Nodes.csproj
+++ b/Nodes/VVVV.DX11.Nodes/VVVV.DX11.Nodes.csproj
@@ -94,8 +94,11 @@
     <Compile Include="Nodes\Textures\2D\AsTextureNode.cs" />
     <Compile Include="Nodes\Textures\2D\PixelData.cs" />
     <Compile Include="Nodes\Textures\3D\FrameDelayTexture3dNode.cs" />
+    <Compile Include="Nodes\Textures\Array\CopySubArrayNode.cs" />
     <Compile Include="Nodes\Textures\Array\GetSliceDepthTextureArray.cs" />
+    <Compile Include="Nodes\Textures\Array\GetSliceToArray.cs" />
     <Compile Include="Nodes\Textures\Array\GetSliceTextureArray.cs" />
+    <Compile Include="Nodes\Textures\Array\CopySubArray.cs" />
     <Compile Include="Nodes\Textures\Array\TextureArraySetSlice.cs" />
     <Compile Include="Nodes\Textures\Array\TextureArraySetSliceNode.cs" />
     <Compile Include="Nodes\Validators\RemoveSliceValidatorNode.cs" />

--- a/Nodes/VVVV.DX11.Nodes/VVVV.DX11.Nodes.csproj
+++ b/Nodes/VVVV.DX11.Nodes/VVVV.DX11.Nodes.csproj
@@ -94,8 +94,10 @@
     <Compile Include="Nodes\Textures\2D\AsTextureNode.cs" />
     <Compile Include="Nodes\Textures\2D\PixelData.cs" />
     <Compile Include="Nodes\Textures\3D\FrameDelayTexture3dNode.cs" />
-    <Compile Include="Nodes\Textures\Array\CopySubArrayNode.cs" />
+    <Compile Include="Nodes\Textures\Array\GetArraysNode.cs" />
+    <Compile Include="Nodes\Textures\Array\GetArrayNode.cs" />
     <Compile Include="Nodes\Textures\Array\GetSliceDepthTextureArray.cs" />
+    <Compile Include="Nodes\Textures\Array\GetArrayToArray.cs" />
     <Compile Include="Nodes\Textures\Array\GetSliceToArray.cs" />
     <Compile Include="Nodes\Textures\Array\GetSliceTextureArray.cs" />
     <Compile Include="Nodes\Textures\Array\CopySubArray.cs" />


### PR DESCRIPTION
Hello Mr. Vux,

These 2 Nodes can come quite handy when dealing with Texturearrays.

**GetSlice (DX11.TextureArray ToArray)** takes a Spread of Textures and creates a new Array for each Index Bin.
**GetArray (DX11.TextureArray)** does quite the Same but for TextureArrays and not (yet) binsizeable.

I'm not sure if you have some improvements or see fundamental bugs, so consider this a proposal where I'm open to discuss things widely. So, any suggestions or critics are super welcome!

Helppatches are available (see images), but since all the helppatches are in the girlpower repo, i can add them if the PR is getting merged.

![image](https://user-images.githubusercontent.com/646501/38882133-b6eafe24-4269-11e8-818c-4e92ca07bc95.png)

![image 1](https://user-images.githubusercontent.com/646501/38882141-bd6520b8-4269-11e8-9379-d4930c1a5417.png)

